### PR TITLE
GE: Remove reduced number of conditional additions

### DIFF
--- a/m4asm/gf16mat_gauss_elim_64.S
+++ b/m4asm/gf16mat_gauss_elim_64.S
@@ -267,13 +267,24 @@ gf16mat_gauss_elim_row_echolen_m4f_64:
         // First: make sure that pivot in this row is not zero, by adding the other rows in case it is zero
         add.w jj, ii, #1
 
-        # add at most 15 rows
+        .if 0
+        // this is a performance optimization resulting in a 2^-58 chance to
+        // wrongly reject a set of vinegar variables.
+        // We disable this trick by default as it it is incompatible with formal verification.
+        // See `Reducing the number of conditional additions` of
+        // https://eprint.iacr.org/2023/059
+
+        // add at most 15 rows
         add.w aj, ii, #16
         cmp.w aj, #64
         it ge
         movge.w aj, #64
         nop.n
         vmov.w stopjj, aj
+        .else
+        mov.w aj, #64
+        vmov.w stopjj, aj
+        .endif
 
         add.w aj, ai, #36
         inner:

--- a/m4asm/gf256mat_gauss_elim_44.S
+++ b/m4asm/gf256mat_gauss_elim_44.S
@@ -294,10 +294,21 @@
 
     add.w \aj, \ai, #48
 
+    .if 0
+    // this is a performance optimization resulting in a 2^-57.4 chance to
+    // wrongly reject a set of vinegar variables.
+    // We disable this trick by default as it it is incompatible with formal verification.
+    // See `Reducing the number of conditional additions` of
+    // https://eprint.iacr.org/2023/059
+
     cmp.n \ii, #36
     ite lt
     movlt.w \ajmax, #8
     rsbge.w \ajmax, \ii, #44
+    .else
+    rsb.w \ajmax, \ii, #44
+    .endif
+
     mov.w \tmp0, #48
     mla.w \ajmax, \ajmax, \tmp0, \ai
 


### PR DESCRIPTION
In https://eprint.iacr.org/2023/059, we propose a trick (see 'Reducing the number of conditional additions' paragraph) to reduce the number of conditional additions by adding a fixed number of rows resulting in a very small chance (~2^-58) to wrongly refusing a system of equations as not being solvable. In the worst case, we wrongly reject a set of vinegars and sample new ones. Unfortunately, this trick makes formal verification of the implementation much harder (or impossible rather, because there is a small chance it is incorrect). We, hence, disable it by default now.

See the corresponding change in the reference implementation: https://github.com/pqov/pqov/pull/40